### PR TITLE
コアタイムの数値変更/スケジュールページの判定を変更

### DIFF
--- a/ShiftAutoFiller.js
+++ b/ShiftAutoFiller.js
@@ -1,6 +1,6 @@
 class ShiftAutoFiller {
   static #defaultRemoteDay = ['火', '水'];
-  static #zaitakuCoreTime10To14 = '90000040394904';
+  static #zaitakuCoreTime10To14 = '90000065476630';
   #submitBtn;
 
   constructor() {
@@ -12,10 +12,11 @@ class ShiftAutoFiller {
   }
 
   #isSchedulePage() {
-    const pageTitle = document
-        .querySelector(".htBlock-pageTitle")
-        ?.childNodes[3].textContent.replace(/\r?\n/g, "");
-    return pageTitle === 'スケジュール申請';
+    const title = 'スケジュール申請'
+    return document
+        .querySelector(".htBlock-pageTitleSticky")
+        ?.childNodes[3].textContent
+        .includes(title)
   }
 
   #buttonExists() {


### PR DESCRIPTION
2点の不具合により動かなくなっていました。
- KingOfTimeのスケジュールページのHTML構造が変わったため、スケジュールページの判定が常にfalseを返す
- zaitakuCoreTime10To14の値が変化していたため「在宅勤怠の一括入力」ボタンを押すと、火曜日と水曜日に空白が入力される